### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   linux_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/joelbladt/laravel-api-boilerplate/security/code-scanning/1](https://github.com/joelbladt/laravel-api-boilerplate/security/code-scanning/1)

The fix involves adding a `permissions` block at the root of the workflow file to explicitly define the least privileges required for the workflow. In this case, the workflow primarily interacts with repository contents (e.g., checking out code, uploading coverage results). Therefore, it makes sense to set `contents: read` as a baseline. Additionally, since the workflow uploads coverage results, it will need `contents: write` for this specific task. We will add the `permissions` block at the root level and account for this need.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
